### PR TITLE
Adding carpets to vibration occlusion tag

### DIFF
--- a/common/src/main/resources/data/minecraft/tags/blocks/occludes_vibration_signals.json
+++ b/common/src/main/resources/data/minecraft/tags/blocks/occludes_vibration_signals.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "#minecraft:wool",
+	"#minecraft:carpets"
+  ]
+}


### PR DESCRIPTION
Adds the vanilla carpets tag to the vibration occlusion tag, mimicking the behavior of vanilla 1.19.